### PR TITLE
Add German and Chinese

### DIFF
--- a/calculate_metrics.py
+++ b/calculate_metrics.py
@@ -90,6 +90,8 @@ class Metric:
         return metric_result.metric_values[0], metric_result.explanations[0]
 
     def compute_metrics_and_update_db(self, language):
+        if language not in self.metric_fns:
+            return
         if self.local_metric_id is not None:
             value = self.compute_local_metric(language)
             db.update_metric_by_id(value, None, self.local_metric_id)
@@ -108,12 +110,16 @@ def get_factual_consistency(response, source,
             first_factual_consistency_metric = Metric(
                 'factual_consistency', {
                     'en': langcheck.metrics.factual_consistency,
-                    'ja': langcheck.metrics.ja.factual_consistency
+                    'ja': langcheck.metrics.ja.factual_consistency,
+                    'de': langcheck.metrics.de.factual_consistency,
+                    'zh': langcheck.metrics.zh.factual_consistency
                 }, [response, source[:len(source) // 2]], True, False)
             second_factual_consistency_metric = Metric(
                 'factual_consistency', {
                     'en': langcheck.metrics.factual_consistency,
-                    'ja': langcheck.metrics.ja.factual_consistency
+                    'ja': langcheck.metrics.ja.factual_consistency,
+                    'de': langcheck.metrics.de.factual_consistency,
+                    'zh': langcheck.metrics.zh.factual_consistency
                 }, [response, source[len(source) // 2:]], True, False)
             first_score = first_factual_consistency_metric.compute_local_metric(
                 language)
@@ -125,7 +131,9 @@ def get_factual_consistency(response, source,
         factual_consistency_metric = Metric(
             'factual_consistency', {
                 'en': langcheck.metrics.factual_consistency,
-                'ja': langcheck.metrics.ja.factual_consistency
+                'ja': langcheck.metrics.ja.factual_consistency,
+                'de': langcheck.metrics.de.factual_consistency,
+                'zh': langcheck.metrics.zh.factual_consistency
             }, [response, source], True, False)
         return factual_consistency_metric.compute_local_metric(language), None
 
@@ -133,7 +141,9 @@ def get_factual_consistency(response, source,
         factual_consistency_metric = Metric(
             'factual_consistency', {
                 'en': langcheck.metrics.factual_consistency,
-                'ja': langcheck.metrics.ja.factual_consistency
+                'ja': langcheck.metrics.ja.factual_consistency,
+                'de': langcheck.metrics.de.factual_consistency,
+                'zh': langcheck.metrics.zh.factual_consistency
             }, [response, source], False, True)
         return factual_consistency_metric.compute_openai_metric(language)
 

--- a/calculate_metrics.py
+++ b/calculate_metrics.py
@@ -51,7 +51,9 @@ class Metric:
         self.local_metric_id = None
         self.openai_metric_id = None
 
-    def insert_metric_names_to_db(self, log_id):
+    def insert_metric_names_to_db(self, log_id, language):
+        if language not in self.metric_fns:
+            return
         if self.compute_local:
             self.local_metric_id = db.insert_metric(log_id, self.metric_name,
                                                     None, None)
@@ -164,76 +166,100 @@ def main(log_id):
             Metric(
                 'factual_consistency', {
                     'en': langcheck.metrics.factual_consistency,
-                    'ja': langcheck.metrics.ja.factual_consistency
+                    'ja': langcheck.metrics.ja.factual_consistency,
+                    'de': langcheck.metrics.de.factual_consistency,
+                    'zh': langcheck.metrics.zh.factual_consistency
                 }, [response, source], False, True))
     metrics_to_compute.append(
         Metric(
             'context_relevance', {
                 'en': langcheck.metrics.context_relevance,
-                'ja': langcheck.metrics.ja.context_relevance
+                'ja': langcheck.metrics.ja.context_relevance,
+                'de': langcheck.metrics.de.context_relevance
             }, [source, request], False, True))
     metrics_to_compute.append(
         Metric(
             'answer_relevance', {
                 'en': langcheck.metrics.answer_relevance,
-                'ja': langcheck.metrics.ja.answer_relevance
+                'ja': langcheck.metrics.ja.answer_relevance,
+                'de': langcheck.metrics.de.answer_relevance
             }, [response, request], False, True))
     metrics_to_compute.append(
-        Metric('request_toxicity', {
-            'en': langcheck.metrics.toxicity,
-            'ja': langcheck.metrics.ja.toxicity
-        }, [request], enable_local, True))
+        Metric(
+            'request_toxicity', {
+                'en': langcheck.metrics.toxicity,
+                'ja': langcheck.metrics.ja.toxicity,
+                'de': langcheck.metrics.de.toxicity,
+                'zh': langcheck.metrics.zh.toxicity
+            }, [request], enable_local, True))
     metrics_to_compute.append(
-        Metric('response_toxicity', {
-            'en': langcheck.metrics.toxicity,
-            'ja': langcheck.metrics.ja.toxicity
-        }, [response], enable_local, True))
+        Metric(
+            'response_toxicity', {
+                'en': langcheck.metrics.toxicity,
+                'ja': langcheck.metrics.ja.toxicity,
+                'de': langcheck.metrics.de.toxicity,
+                'zh': langcheck.metrics.zh.toxicity
+            }, [response], enable_local, True))
     metrics_to_compute.append(
         Metric(
             'request_sentiment', {
                 'en': langcheck.metrics.sentiment,
-                'ja': langcheck.metrics.ja.sentiment
+                'ja': langcheck.metrics.ja.sentiment,
+                'de': langcheck.metrics.de.sentiment,
+                'zh': langcheck.metrics.zh.sentiment
             }, [request], enable_local, True))
     metrics_to_compute.append(
         Metric(
             'response_sentiment', {
                 'en': langcheck.metrics.sentiment,
-                'ja': langcheck.metrics.ja.sentiment
+                'ja': langcheck.metrics.ja.sentiment,
+                'de': langcheck.metrics.de.sentiment,
+                'zh': langcheck.metrics.zh.sentiment
             }, [response], enable_local, True))
     metrics_to_compute.append(
-        Metric('request_fluency', {
-            'en': langcheck.metrics.fluency,
-            'ja': langcheck.metrics.ja.fluency
-        }, [request], enable_local, True))
+        Metric(
+            'request_fluency', {
+                'en': langcheck.metrics.fluency,
+                'ja': langcheck.metrics.ja.fluency,
+                'de': langcheck.metrics.de.fluency
+            }, [request], enable_local, True))
     metrics_to_compute.append(
-        Metric('response_fluency', {
-            'en': langcheck.metrics.fluency,
-            'ja': langcheck.metrics.ja.fluency
-        }, [response], enable_local, True))
+        Metric(
+            'response_fluency', {
+                'en': langcheck.metrics.fluency,
+                'ja': langcheck.metrics.ja.fluency,
+                'de': langcheck.metrics.de.fluency
+            }, [response], enable_local, True))
     metrics_to_compute.append(
         Metric(
             'request_readability', {
                 'en': langcheck.metrics.flesch_reading_ease,
-                'ja': langcheck.metrics.ja.tateishi_ono_yamada_reading_ease
+                'ja': langcheck.metrics.ja.tateishi_ono_yamada_reading_ease,
+                'de': langcheck.metrics.de.flesch_reading_ease,
+                'zh': langcheck.metrics.zh.xuyaochen_report_readability
             }, [request], True, False))
     metrics_to_compute.append(
         Metric(
             'response_readability', {
                 'en': langcheck.metrics.flesch_reading_ease,
-                'ja': langcheck.metrics.ja.tateishi_ono_yamada_reading_ease
+                'ja': langcheck.metrics.ja.tateishi_ono_yamada_reading_ease,
+                'de': langcheck.metrics.de.flesch_reading_ease,
+                'zh': langcheck.metrics.zh.xuyaochen_report_readability
             }, [response], True, False))
-    # TODO: Use japanese metrics once implemented
+    # TODO: Use japanese and chinese metrics once implemented
     metrics_to_compute.append(
         Metric(
             'ai_disclaimer_similarity', {
                 'en': langcheck.metrics.ai_disclaimer_similarity,
-                'ja': langcheck.metrics.ai_disclaimer_similarity
+                'ja': langcheck.metrics.ai_disclaimer_similarity,
+                'de': langcheck.metrics.de.ai_disclaimer_similarity,
+                'zh': langcheck.metrics.ai_disclaimer_similarity
             }, [response], True, False))
 
     # First, add the metric names to the database, but don't yet compute the
     # metrics
     for metric in metrics_to_compute:
-        metric.insert_metric_names_to_db(log_id)
+        metric.insert_metric_names_to_db(log_id, language)
     db.update_chatlog_by_id({'status': 'pending'}, log_id)
 
     # Then, compute the metrics and update the database

--- a/calculate_reference_metrics.py
+++ b/calculate_reference_metrics.py
@@ -14,15 +14,23 @@ def main(log_id, reference):
     db.update_chatlog_by_id({'status': 'new', 'reference': reference}, log_id)
 
     metrics_to_compute = [
-        Metric('rouge1', langcheck.metrics.rouge1, langcheck.metrics.ja.rouge1,
-               [response, reference, request], True, False),
-        Metric('rouge2', langcheck.metrics.rouge2, langcheck.metrics.ja.rouge2,
-               [response, reference, request], True, False),
-        Metric('rougeL', langcheck.metrics.rougeL, langcheck.metrics.ja.rougeL,
-               [response, reference, request], True, False),
-        Metric('semantic_similarity', langcheck.metrics.semantic_similarity,
-               langcheck.metrics.ja.semantic_similarity,
-               [response, reference, request], True, False)
+        Metric('rouge1', {
+            'en': langcheck.metrics.rouge1,
+            'ja': langcheck.metrics.ja.rouge1
+        }, [response, reference, request], True, False),
+        Metric('rouge2', {
+            'en': langcheck.metrics.rouge2,
+            'ja': langcheck.metrics.ja.rouge2
+        }, [response, reference, request], True, False),
+        Metric('rougeL', {
+            'en': langcheck.metrics.rougeL,
+            'ja': langcheck.metrics.ja.rougeL
+        }, [response, reference, request], True, False),
+        Metric(
+            'semantic_similarity', {
+                'en': langcheck.metrics.semantic_similarity,
+                'ja': langcheck.metrics.ja.semantic_similarity
+            }, [response, reference, request], True, False)
     ]
 
     # First, add the metric names to the database, but don't yet compute the

--- a/calculate_reference_metrics.py
+++ b/calculate_reference_metrics.py
@@ -14,22 +14,33 @@ def main(log_id, reference):
     db.update_chatlog_by_id({'status': 'new', 'reference': reference}, log_id)
 
     metrics_to_compute = [
-        Metric('rouge1', {
-            'en': langcheck.metrics.rouge1,
-            'ja': langcheck.metrics.ja.rouge1
-        }, [response, reference, request], True, False),
-        Metric('rouge2', {
-            'en': langcheck.metrics.rouge2,
-            'ja': langcheck.metrics.ja.rouge2
-        }, [response, reference, request], True, False),
-        Metric('rougeL', {
-            'en': langcheck.metrics.rougeL,
-            'ja': langcheck.metrics.ja.rougeL
-        }, [response, reference, request], True, False),
+        Metric(
+            'rouge1', {
+                'en': langcheck.metrics.rouge1,
+                'ja': langcheck.metrics.ja.rouge1,
+                'de': langcheck.metrics.de.rouge1,
+                'zh': langcheck.metrics.zh.rouge1
+            }, [response, reference, request], True, False),
+        Metric(
+            'rouge2', {
+                'en': langcheck.metrics.rouge2,
+                'ja': langcheck.metrics.ja.rouge2,
+                'de': langcheck.metrics.de.rouge2,
+                'zh': langcheck.metrics.zh.rouge2
+            }, [response, reference, request], True, False),
+        Metric(
+            'rougeL', {
+                'en': langcheck.metrics.rougeL,
+                'ja': langcheck.metrics.ja.rougeL,
+                'de': langcheck.metrics.de.rougeL,
+                'zh': langcheck.metrics.zh.rougeL
+            }, [response, reference, request], True, False),
         Metric(
             'semantic_similarity', {
                 'en': langcheck.metrics.semantic_similarity,
-                'ja': langcheck.metrics.ja.semantic_similarity
+                'ja': langcheck.metrics.ja.semantic_similarity,
+                'de': langcheck.metrics.de.semantic_similarity,
+                'zh': langcheck.metrics.zh.semantic_similarity
             }, [response, reference, request], True, False)
     ]
 

--- a/calculate_reference_metrics.py
+++ b/calculate_reference_metrics.py
@@ -36,7 +36,7 @@ def main(log_id, reference):
     # First, add the metric names to the database, but don't yet compute the
     # metrics
     for metric in metrics_to_compute:
-        metric.insert_metric_names_to_db(log_id)
+        metric.insert_metric_names_to_db(log_id, language)
     db.update_chatlog_by_id({'status': 'pending'}, log_id)
 
     # Then, compute the metrics and update the database

--- a/rag.py
+++ b/rag.py
@@ -34,6 +34,10 @@ class RAG:
         # Generate response message
         if language == 'ja':
             user_message_sent = '日本語で答えてください\n' + user_message
+        elif language == 'de':
+            user_message_sent = 'Bitte antworte auf Deutsch\n' + user_message
+        elif language == 'zh':
+            user_message_sent = '请用中文回答\n' + user_message
         else:
             user_message_sent = user_message
         response = self.index.as_query_engine().query(user_message_sent)

--- a/rag.py
+++ b/rag.py
@@ -5,8 +5,8 @@ import tempfile
 from pathlib import Path
 
 from dotenv import load_dotenv
-from llama_index.core import (GPTVectorStoreIndex, ServiceContext,
-                              set_global_service_context)
+from llama_index.core import ServiceContext, set_global_service_context
+from llama_index.core.indices import GPTVectorStoreIndex
 from llama_index.core.readers import StringIterableReader
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,8 @@
       <select id="language-toggle" class="custom-select custom-select-sm" style="width: 100px;">
         <option value="en" selected>English</option>
         <option value="ja">日本語</option>
+        <option value="de">Deutsch</option>
+        <option value="zh">中文</option>
       </select>
     </div>
 


### PR DESCRIPTION
Adds German and Chinese options.
<img width="1022" alt="image" src="https://github.com/citadel-ai/langcheckchat/assets/107823399/e9823327-94b8-4c29-8967-c32f553bae9c">


For Chinese, not all metrics have been implemented yet, so we just show the supported metrics
<img width="1153" alt="image" src="https://github.com/citadel-ai/langcheckchat/assets/107823399/53cf7ef5-6b65-4bd1-ae40-7d2f2c5fe27b">
